### PR TITLE
format limits safely check data references

### DIFF
--- a/keywords/dot/_formatLimit.jst
+++ b/keywords/dot/_formatLimit.jst
@@ -33,7 +33,7 @@ var {{=$valid}} = undefined;
 
 {{
   var $schemaFormat = it.schema.format
-    , $isDataFormat = it.opts.$data && $schemaFormat.$data
+    , $isDataFormat = it.opts.$data && typeof $schemaFormat === "object" && $schemaFormat.$data
     , $closingBraces = '';
 }}
 
@@ -58,7 +58,7 @@ var {{=$valid}} = undefined;
   var $isMax = $keyword == 'formatMaximum'
     , $exclusiveKeyword = 'formatExclusive' + ($isMax ? 'Maximum' : 'Minimum')
     , $schemaExcl = it.schema[$exclusiveKeyword]
-    , $isDataExcl = it.opts.$data && $schemaExcl && $schemaExcl.$data
+    , $isDataExcl = it.opts.$data && typeof $schemaExcl === "object" && $schemaExcl.$data
     , $op = $isMax ? '<' : '>'
     , $result = 'result' + $lvl;
 }}


### PR DESCRIPTION
When using {... $data: true } options in ajv, the checks for "format" and format...Exclusive schemas being data references results in exceptions since the schema is treated as an object when it could be a string.