### PR TITLE
Fix #106: add ts definitions to published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "files": [
     "index.js",
+    "ajv-keywords.d.ts",
     "keywords"
   ],
   "author": "Evgeny Poberezkin",


### PR DESCRIPTION
In #106 the typescript definitions were added but they aren't included in the published package. This is because they aren't part of the `files` array in the `package.json`. 

This causes VS Code to complain about the missing definitions for me.