### PR TITLE
Fixed ajvKeywords.default is not a function.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,3 +27,6 @@ function get(keyword: string): Plugin<any> {
 
 export default ajvKeywords
 module.exports = ajvKeywords
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+module.exports.default = ajvKeywords


### PR DESCRIPTION
Refer to ajv-formats at: https://github.com/ajv-validator/ajv-formats/blob/ce49433448384b4c0b2407adafc345e43b85f8ea/src/index.ts#L63