### PR TITLE
Don't mutate a schema with a transform keyword while compiling it.

### DIFF
--- a/spec/transform.spec.ts
+++ b/spec/transform.spec.ts
@@ -129,4 +129,15 @@ describe('keyword "transform"', () => {
       data.should.deep.equal(["ab"])
     })
   })
+
+  ajvs.forEach((ajv, i) => {
+    it(`shouldn't mutate the transform array of the schema while compiling it #${i}`, () => {
+      const data = {p: "  trimObject  "}
+      const schema = {type: "object", properties: {p: {type: "string", transform: ["trimLeft"]}}}
+      ajv.validate(schema, data).should.equal(true)
+      data.should.deep.equal({p: "trimObject  "})
+
+      schema.properties.p.transform.should.deep.equal(["trimLeft"])
+    })
+  })
 })

--- a/src/definitions/transform.ts
+++ b/src/definitions/transform.ts
@@ -48,7 +48,7 @@ function _getDef(): CodeKeywordDefinition {
         cfg = gen.scopeValue("obj", {ref: config, code: stringify(config)})
       }
       gen.if(_`typeof ${data} == "string" && ${parentData} !== undefined`, () => {
-        gen.assign(data, transformExpr(tNames))
+        gen.assign(data, transformExpr(tNames.slice()))
         gen.assign(_`${parentData}[${parentDataProperty}]`, data)
       })
 


### PR DESCRIPTION
=> If the schema is compiled twice, the second validator function won't work properly since the transform array will have been emptied.