### PR TITLE
Replace prepublish with prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "prettier:write": "prettier --write \"./**/*.{md,json,yaml,js,ts}\"",
     "prettier:check": "prettier --list-different \"./**/*.{md,json,yaml,js,ts}\"",
     "test": "npm link && npm link ajv-keywords && npm run eslint && npm run test-cov",


### PR DESCRIPTION
https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts

prepublish is run before `npm ci` and `npm install` ( but not before `npm publish`).

This makes `npm ci --production` fail, since in this case npm will not install typescript before trying to build the project.