### PR TITLE
fix yarn berry issue with trying to access to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,16 @@
   },
   "homepage": "https://github.com/epoberezkin/ajv-keywords#readme",
   "dependencies": {
+    "ajv": "^8.0.0",
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
     "ajv": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ajv": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@ajv-validator/config": "^0.2.3",


### PR DESCRIPTION
Hello. I'm working with yarn berry in PnP mode and got the next issue

```shell
Error: ajv-keywords tried to access ajv (a peer dependency) but it isn't provided by your application; this makes the require call ambiguous and unsound.

Required package: ajv (via "ajv/dist/compile/codegen")
Required by: ajv-keywords@virtual:1fbf6783dc10470f994b99f2b6f56c3fa8279e2feebc5cc2acae388dbccf6a57a9ca1def1c609e283fb2603c4b5e4d3a472c47209820642d79ca08629388f997#npm:5.0.0 (via <trimmed>/.yarn/$$virtual/ajv-keywords-virtual-4a3ede7eec/0/cache/ajv-keywords-npm-5.0.0-50b946aaa2-362c9fecab.zip/node_modules/ajv-keywords/dist/definitions/)
Ancestor breaking the chain: picflow@workspace:.
```

Previously I have used `ajv-formats` lib and that lib works well. I just copied the `package.json` from `ajv-formats` and insert it into `ajv-keywords`. What do you think about this fix? I think it can work, but here can be some potential case when an application will have 2 instances of ajv and the user's yarn cache will grow in size, but still, it will be very rare case