### PR TITLE
Added normalize transform option to normalize string spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ A standalone string cannot be modified, i.e. `data = 'a'; ajv.validate(schema, d
 - `toLowerCase`: convert to lower case
 - `toUpperCase`: convert to upper case
 - `toEnumCase`: change string case to be equal to one of `enum` values in the schema
+- `normalize`: replace inner multiple spaces with a single space
 
 Transformations are applied in the order they are listed.
 

--- a/spec/transform.spec.ts
+++ b/spec/transform.spec.ts
@@ -129,4 +129,30 @@ describe('keyword "transform"', () => {
       data.should.deep.equal(["ab"])
     })
   })
+
+  ajvs.forEach((ajv, i) => {
+    it(`should transform normalize #${i}`, () => {
+      let schema, data
+
+      data = ["  normalize  object    to test  "]
+      schema = {type: "array", items: {type: "string", transform: ["normalize"]}}
+      ajv.validate(schema, data).should.equal(true)
+      data.should.deep.equal([" normalize object to test "])
+
+      data = ["normalize"]
+      schema = {type: "array", items: {type: "string", transform: ["normalize"]}}
+      ajv.validate(schema, data).should.equal(true)
+      data.should.deep.equal(["normalize"])
+
+      data = ["normalize object to test"]
+      schema = {type: "array", items: {type: "string", transform: ["normalize"]}}
+      ajv.validate(schema, data).should.equal(true)
+      data.should.deep.equal(["normalize object to test"])
+
+      data = ["normalize  object to    test"]
+      schema = {type: "array", items: {type: "string", transform: ["normalize"]}}
+      ajv.validate(schema, data).should.equal(true)
+      data.should.deep.equal(["normalize object to test"])
+    })
+  })
 })

--- a/src/definitions/transform.ts
+++ b/src/definitions/transform.ts
@@ -10,6 +10,7 @@ type TransformName =
   | "toLowerCase"
   | "toUpperCase"
   | "toEnumCase"
+  | "normalize"
 
 interface TransformConfig {
   hash: Record<string, string | undefined>
@@ -26,6 +27,7 @@ const transform: {[key in TransformName]: Transform} = {
   toLowerCase: (s) => s.toLowerCase(),
   toUpperCase: (s) => s.toUpperCase(),
   toEnumCase: (s, cfg) => cfg?.hash[configKey(s)] || s,
+  normalize: (s) => s.replace(/\s\s+/g, " "),
 }
 
 const getDef: (() => CodeKeywordDefinition) & {


### PR DESCRIPTION
I added a normalize option for transform, a normalize option just basically removes multiple spaces and replaces them with a single space, I have been custom doing this in my previous projects and I thought this might be useful